### PR TITLE
December 2024 Release - Bump splunktaucclib (#78)

### DIFF
--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,3 +1,3 @@
 # Using boto3 included in Splunk libs 
 # boto3==1.26.61
-splunktaucclib==6.5.0
+splunktaucclib==6.5.3


### PR DESCRIPTION
Bumps the splunk group with 1 update in the /package/lib directory: splunktaucclib.


Updates `splunktaucclib` from 6.5.0 to 6.5.3

---
updated-dependencies:
- dependency-name: splunktaucclib dependency-type: direct:production update-type: version-update:semver-patch dependency-group: splunk ...